### PR TITLE
Add GitHub Skills activity to extracurricular activities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal during the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities dictionary in `app.py`
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Maximum capacity: 25 participants
- Description includes mention of GitHub Certifications program for college applications

## Context
Students reported that the GitHub Skills activity was announced but missing from the signup page. This is time-sensitive as registrations close by the end of this week.

Fixes #6

## Testing
- [x] Activity added to the system
- [x] Follows the same structure as other activities
- [x] Ready for students to sign up